### PR TITLE
Update running in eclipse instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Installing WDT on Eclipse is as simple as a drag-and-drop, but the process is ex
 
 #### Import project and running in Eclipse/WDT:
 
-1.	Select menu File -> Import -> Maven -> Existing Maven Projects.
-2.	Select Browse... to the top level directory titled sample.javaee7.concurrency and select Finish
-3.	Click Yes to the WebSphere Liberty dialog to automatically create server in the Servers view for this project.
-4.  Right-click the project and select Run As > Run on Server.
-5.  Select the server and click Finish.
+1.	Select menu *File -> Import -> Maven -> Existing Maven Projects*.
+2.	Select *Browse...* to the top level directory titled sample.javaee7.concurrency and select *Finish*.
+3.	Click *Yes* to the WebSphere Liberty dialog to automatically create server in the Servers view for this project.
+4.  Right-click the project and select *Run As > Run on Server*.
+5.  Select the server and click *Finish*.
 6.  Confirm web browser opens with the sample url: [http://hostname:port/sample.javaee7.jta/](http://hostname:port/sample.javaee7.jta/)
 
 ### WAS Classic

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,40 @@
 
     <build>
         <finalName>${project.artifactId}</finalName>
+
+        <pluginManagement>
+            <plugins>
+                <!-- include dependency:copy in the eclipse M2E lifecycle -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>3.0.0</versionRange>
+                                        <goals>
+                                            <goal>copy</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>false</runOnIncremental>
+                                            <runOnConfiguration>true</runOnConfiguration>
+                                        </execute>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -124,10 +158,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>copy</id>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>copy</goal>
                         </goals>

--- a/src/main/wlp/server.xml
+++ b/src/main/wlp/server.xml
@@ -20,6 +20,7 @@
         <properties.derby.embedded createDatabase="create" databaseName="${shared.resource.dir}/derby/JTASAMPLE"/>
     </dataSource>
 
-    <application name="sample.javaee7.servlet.jta" context-root="/sample.javaee7.jta" location="${appLocation}" type="war"/>
+    <application name="sample.javaee7.jta" context-root="/sample.javaee7.jta" location="${appLocation}" type="war"/>
 
 </server>
+


### PR DESCRIPTION
This project uses maven-dependency-plugin to copy derby datasource to target liberty shared resource location, but dependency:copy is not bound to the m2e life cycle.  

Bind dependency:copy to m2e lifecycle to copy derby datasource during import into eclipse.